### PR TITLE
Revise documentation, add benchmarks

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -122,6 +122,8 @@ set(SWIFT_BENCH_MODULES
     single-source/Queue
     single-source/RC4
     single-source/RGBHistogram
+    single-source/RandomShuffle
+    single-source/RandomValues
     single-source/RangeAssignment
     single-source/RangeIteration
     single-source/RangeReplaceableCollectionPlusDefault

--- a/benchmark/single-source/RandomShuffle.swift
+++ b/benchmark/single-source/RandomShuffle.swift
@@ -1,0 +1,64 @@
+//===--- RandomShuffle.swift ----------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import TestsUtils
+
+//
+// Benchmark that shuffles arrays of integers. Measures the performance of
+// shuffling large arrays.
+//
+
+public let RandomShuffle = [
+  BenchmarkInfo(name: "RandomShuffleDef", runFunction: run_RandomShuffleDef,
+    tags: [.api], setUpFunction: setup_RandomShuffle),
+  BenchmarkInfo(name: "RandomShuffleLCG", runFunction: run_RandomShuffleLCG,
+    tags: [.api], setUpFunction: setup_RandomShuffle),
+]
+
+/// A linear congruential PRNG.
+final class LCRNG: RandomNumberGenerator {
+  private var state: UInt64
+  
+  init(seed: Int) {
+    state = UInt64(truncatingIfNeeded: seed)
+    for _ in 0..<10 { _ = next() }
+  }
+  
+  func next() -> UInt64 {
+    state = 2862933555777941757 &* state &+ 3037000493
+    return state
+  }
+}
+
+var numbers = Array(0...3_000_000)
+
+@inline(never)
+func setup_RandomShuffle() {
+  _ = numbers.count
+}
+
+@inline(never)
+public func run_RandomShuffleDef(_ N: Int) {
+  for _ in 0 ..< N {
+    numbers.shuffle()
+    blackHole(numbers.first!)
+  }
+}
+
+@inline(never)
+public func run_RandomShuffleLCG(_ N: Int) {
+  let generator = LCRNG(seed: 0)
+  for _ in 0 ..< N {
+    numbers.shuffle(using: generator)
+    blackHole(numbers.first!)
+  }
+}

--- a/benchmark/single-source/RandomValues.swift
+++ b/benchmark/single-source/RandomValues.swift
@@ -1,0 +1,87 @@
+//===--- RandomValues.swift -----------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import TestsUtils
+
+//
+// Benchmark generating lots of random values. Measures the performance of
+// the default random generator and the algorithms for generating integers
+// and floating-point values.
+//
+
+public let RandomValues = [
+  BenchmarkInfo(name: "RandomIntegersDef", runFunction: run_RandomIntegersDef, tags: [.api]),
+  BenchmarkInfo(name: "RandomIntegersLCG", runFunction: run_RandomIntegersLCG, tags: [.api]),
+  BenchmarkInfo(name: "RandomDoubleDef", runFunction: run_RandomDoubleDef, tags: [.api]),
+  BenchmarkInfo(name: "RandomDoubleLCG", runFunction: run_RandomDoubleLCG, tags: [.api]),
+]
+
+/// A linear congruential PRNG.
+final class LCRNG: RandomNumberGenerator {
+  private var state: UInt64
+  
+  init(seed: Int) {
+    state = UInt64(truncatingIfNeeded: seed)
+    for _ in 0..<10 { _ = next() }
+  }
+  
+  func next() -> UInt64 {
+    state = 2862933555777941757 &* state &+ 3037000493
+    return state
+  }
+}
+
+@inline(never)
+public func run_RandomIntegersDef(_ N: Int) {
+  for _ in 0 ..< N {
+    var x = 0
+    for _ in 0 ..< 100_000 {
+      x &+= Int.random(in: 0...10_000)
+    }
+    blackHole(x)
+  }
+}
+
+@inline(never)
+public func run_RandomIntegersLCG(_ N: Int) {
+  for _ in 0 ..< N {
+    var x = 0
+    let generator = LCRNG(seed: 0)
+    for _ in 0 ..< 100_000 {
+      x &+= Int.random(in: 0...10_000, using: generator)
+    }
+    CheckResults(x == 498214315)
+  }
+}
+
+@inline(never)
+public func run_RandomDoubleDef(_ N: Int) {
+  for _ in 0 ..< N {
+    var x = 0.0
+    for _ in 0 ..< 100_000 {
+      x += Double.random(in: -1000...1000)
+    }
+    blackHole(x)
+  }
+}
+
+@inline(never)
+public func run_RandomDoubleLCG(_ N: Int) {
+  for _ in 0 ..< N {
+    var x = 0.0
+    let generator = LCRNG(seed: 0)
+    for _ in 0 ..< 100_000 {
+      x += Double.random(in: -1000...1000, using: generator)
+    }
+    blackHole(x)
+  }
+}

--- a/benchmark/utils/main.swift
+++ b/benchmark/utils/main.swift
@@ -110,6 +110,8 @@ import ProtocolDispatch2
 import Queue
 import RC4
 import RGBHistogram
+import RandomShuffle
+import RandomValues
 import RangeAssignment
 import RangeIteration
 import RangeReplaceableCollectionPlusDefault
@@ -264,6 +266,8 @@ registerBenchmark(QueueGeneric)
 registerBenchmark(QueueConcrete)
 registerBenchmark(RC4Test)
 registerBenchmark(RGBHistogram)
+registerBenchmark(RandomShuffle)
+registerBenchmark(RandomValues)
 registerBenchmark(RangeAssignment)
 registerBenchmark(RangeIteration)
 registerBenchmark(RangeReplaceableCollectionPlusDefault)

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -790,24 +790,21 @@ public protocol Collection: Sequence where SubSequence: Collection {
   ///   `endIndex`.
   func formIndex(after i: inout Index)
 
-  /// Returns a random element from this collection.
+  /// Returns a random element of the collection, using the given generator as
+  /// a source for randomness.
   ///
-  /// - Parameter generator: The random number generator to use when getting
+  /// You use this method to select a random element from a collection when you
+  /// are using a custom random number generator. For example, call
+  /// `random(using:)` to select a random element from an array of names.
+  ///
+  ///     let names = ["Zoey", "Chloe", "Amani", "Amaia"]
+  ///     let randomName = names.random(using: myGenerator)!
+  ///     // randomName == "Amani" (maybe)
+  ///
+  /// - Parameter generator: The random number generator to use when choosing
   ///   a random element.
-  /// - Returns: A random element from this collection.
-  ///
-  /// A good example of this is getting a random greeting from an array:
-  ///
-  ///     let greetings = ["hi", "hey", "hello", "hola"]
-  ///     let randomGreeting = greetings.random()
-  ///
-  /// If the collection is empty, the value of this function is `nil`.
-  ///
-  ///     let numbers = [10, 20, 30, 40, 50]
-  ///     if let randomNumber = numbers.random() {
-  ///         print(randomNumber)
-  ///     }
-  ///     // Could print "20", perhaps
+  /// - Returns: A random element from the collection. If the collection is
+  ///   empty, the method returns `nil`.
   func random<T: RandomNumberGenerator>(using generator: T) -> Element?
 
   @available(*, deprecated, message: "all index distances are now of type Int")
@@ -1023,24 +1020,21 @@ extension Collection {
     return count
   }
 
-  /// Returns a random element from this collection.
+  /// Returns a random element of the collection, using the given generator as
+  /// a source for randomness.
   ///
-  /// - Parameter generator: The random number generator to use when getting
+  /// You use this method to select a random element from a collection when you
+  /// are using a custom random number generator. For example, call
+  /// `random(using:)` to select a random element from an array of names.
+  ///
+  ///     let names = ["Zoey", "Chloe", "Amani", "Amaia"]
+  ///     let randomName = names.random(using: myGenerator)!
+  ///     // randomName == "Amani" (maybe)
+  ///
+  /// - Parameter generator: The random number generator to use when choosing
   ///   a random element.
-  /// - Returns: A random element from this collection.
-  ///
-  /// A good example of this is getting a random greeting from an array:
-  ///
-  ///     let greetings = ["hi", "hey", "hello", "hola"]
-  ///     let randomGreeting = greetings.random()
-  ///
-  /// If the collection is empty, the value of this function is `nil`.
-  ///
-  ///     let numbers = [10, 20, 30, 40, 50]
-  ///     if let randomNumber = numbers.random() {
-  ///         print(randomNumber)
-  ///     }
-  ///     // Could print "20", perhaps
+  /// - Returns: A random element from the collection. If the collection is
+  ///   empty, the method returns `nil`.
   @inlinable
   public func random<T: RandomNumberGenerator>(
     using generator: T
@@ -1054,26 +1048,21 @@ extension Collection {
     return self[index]
   }
 
-  /// Returns a random element from this collection.
+  /// Returns a random element of the collection.
   ///
-  /// - Parameter generator: The random number generator to use when getting
-  ///   a random element.
-  /// - Returns: A random element from this collection.
+  /// For example, call `random()` to select a random element from an
+  /// array of names.
   ///
-  /// A good example of this is getting a random greeting from an array:
+  ///     let names = ["Zoey", "Chloe", "Amani", "Amaia"]
+  ///     let randomName = names.random()!
+  ///     // randomName == "Amani" (perhaps)
   ///
-  ///     let greetings = ["hi", "hey", "hello", "hola"]
-  ///     let randomGreeting = greetings.random()
+  /// This method uses the default random generator, `Random.default`. The call
+  /// to `names.random()` above is equivalent to calling
+  /// `names.random(using: Random.default)`.
   ///
-  /// If the collection is empty, the value of this function is `nil`.
-  ///
-  ///     let numbers = [10, 20, 30, 40, 50]
-  ///     if let randomNumber = numbers.random() {
-  ///         print(randomNumber)
-  ///     }
-  ///     // Could print "20", perhaps
-  ///
-  /// This uses the standard library's default random number generator.
+  /// - Returns: A random element from the collection. If the collection is
+  ///   empty, the method returns `nil`.
   @inlinable
   public func random() -> Element? {
     return random(using: Random.default)

--- a/stdlib/public/core/CollectionAlgorithms.swift
+++ b/stdlib/public/core/CollectionAlgorithms.swift
@@ -265,11 +265,23 @@ extension MutableCollection where Self : BidirectionalCollection {
 //===----------------------------------------------------------------------===//
 
 extension Sequence {
-  /// Returns the elements of the sequence, shuffled.
+  /// Returns the elements of the sequence, shuffled using the given generator
+  /// as a source for randomness.
+  ///
+  /// You use this method to randomize the elements of a sequence when you
+  /// are using a custom random number generator. For example, you can shuffle
+  /// the numbers between `0` and `9` by calling the `shuffled(using:)` method
+  /// on that range:
+  ///
+  ///     let numbers = 0...9
+  ///     let shuffledNumbers = numbers.shuffled(using: myGenerator)
+  ///     // shuffledNumbers == [8, 9, 4, 3, 2, 6, 7, 0, 5, 1]
   ///
   /// - Parameter generator: The random number generator to use when shuffling
   ///   the sequence.
-  /// - Returns: A shuffled array of this sequence's elements.
+  /// - Returns: An array of this sequence's elements in a shuffled order.
+  ///
+  /// - Complexity: O(*n*)
   @inlinable
   public func shuffled<T: RandomNumberGenerator>(
     using generator: T
@@ -281,11 +293,22 @@ extension Sequence {
   
   /// Returns the elements of the sequence, shuffled.
   ///
+  /// For example, you can shuffle the numbers between `0` and `9` by calling
+  /// the `shuffled()` method on that range:
+  ///
+  ///     let numbers = 0...9
+  ///     let shuffledNumbers = numbers.shuffled()
+  ///     // shuffledNumbers == [1, 7, 6, 2, 8, 9, 4, 3, 5, 0]
+  ///
+  /// This method uses the default random generator, `Random.default`. The call
+  /// to `numbers.shuffled()` above is equivalent to calling
+  /// `numbers.shuffled(using: Random.default)`.
+  ///
   /// - Parameter generator: The random number generator to use when shuffling
   ///   the sequence.
   /// - Returns: A shuffled array of this sequence's elements.
   ///
-  /// This uses the standard library's default random number generator.
+  /// - Complexity: O(*n*)
   @inlinable
   public func shuffled() -> [Element] {
     return shuffled(using: Random.default)
@@ -293,10 +316,21 @@ extension Sequence {
 }
 
 extension MutableCollection {
-  /// Shuffles the collection in place.
+  /// Shuffles the collection in place, using the given generator as a source
+  /// for randomness.
+  ///
+  /// You use this method to randomize the elements of a collection when you
+  /// are using a custom random number generator. For example, you can use the
+  /// `shuffle(using:)` method to randomly reorder the elements of an array.
+  ///
+  ///     var names = ["Alejandro", "Camila", "Diego", "Luciana", "Luis", "Sofía"]
+  ///     names.shuffle(using: myGenerator)
+  ///     // names == ["Sofía", "Alejandro", "Camila", "Luis", "Diego", "Luciana"]
   ///
   /// - Parameter generator: The random number generator to use when shuffling
   ///   the collection.
+  ///
+  /// - Complexity: O(*n*)
   @inlinable
   public mutating func shuffle<T: RandomNumberGenerator>(
     using generator: T
@@ -317,10 +351,18 @@ extension MutableCollection {
   
   /// Shuffles the collection in place.
   ///
-  /// - Parameter generator: The random number generator to use when shuffling
-  ///   the collection.
+  /// Use the `shuffle()` method to randomly reorder the elements of an
+  /// array.
   ///
-  /// This uses the standard library's default random number generator.
+  ///     var names = ["Alejandro", "Camila", "Diego", "Luciana", "Luis", "Sofía"]
+  ///     names.shuffle(using: myGenerator)
+  ///     // names == ["Luis", "Camila", "Luciana", "Sofía", "Alejandro", "Diego"]
+  ///
+  /// This method uses the default random generator, `Random.default`. The call
+  /// to `names.shuffle()` above is equivalent to calling
+  /// `names.shuffle(using: Random.default)`.
+  ///
+  /// - Complexity: O(*n*)
   @inlinable
   public mutating func shuffle() {
     shuffle(using: Random.default)

--- a/stdlib/public/core/FloatingPoint.swift.gyb
+++ b/stdlib/public/core/FloatingPoint.swift.gyb
@@ -2375,19 +2375,40 @@ extension BinaryFloatingPoint {
 }
 
 % for Range in ['Range', 'ClosedRange']:
-
+%   exampleRange = '10.0..<20.0' if Range == 'Range' else '10.0...20.0'
 extension BinaryFloatingPoint
 where Self.RawSignificand : FixedWidthInteger,
       Self.RawSignificand.Stride : SignedInteger & FixedWidthInteger,
       Self.RawSignificand.Magnitude : UnsignedInteger {
 
-  /// Returns a random representation of this floating point within the range.
+  /// Returns a random value within the specified range, using the given
+  /// generator as a source for randomness.
   ///
-  /// - Parameter range: A ${Range} to determine the bounds to get a random value
-  ///   from.
-  /// - Parameter generator: The random number generator to use when getting
-  ///   the random floating point.
-  /// - Returns: A random representation of this floating point.
+  /// Use this method to generate a floating-point value within a specific
+  /// range when you are using a custom random number generator. This example
+  /// creates three new values in the range `${exampleRange}`.
+  ///
+  ///     for _ in 1...3 {
+  ///         print(Double.random(in: ${exampleRange}, using: myGenerator))
+  ///     }
+  ///     // Prints "18.1900709259179"
+  ///     // Prints "14.2286325689993"
+  ///     // Prints "13.1485686260762"
+  ///
+  /// The `random(using:)` static method chooses a random value from a
+  /// continuous uniform distribution in `range`, and then converts that value
+  /// to the nearest representable value in this type. Depending on the size and
+  /// span of `range`, some concrete values may be represented more frequently
+  /// than others.
+  ///
+  /// - Parameters:
+  ///   - range: The range in which to create a random value.
+%   if Range == 'Range':
+  ///     `range` must not be empty.
+%   end
+  ///   - generator: The random number generator to use when creating the
+  ///     new random value.
+  /// - Returns: A random value within the bounds of `range`.
   @inlinable
   public static func random<T: RandomNumberGenerator>(
     in range: ${Range}<Self>,
@@ -2413,15 +2434,34 @@ where Self.RawSignificand : FixedWidthInteger,
     return delta * unitRandom + range.lowerBound
   }
 
-  /// Returns a random representation of this floating point within the range.
+  /// Returns a random value within the specified range.
   ///
-  /// - Parameter range: A ${Range} to determine the bounds to get a random value
-  ///   from.
-  /// - Parameter generator: The random number generator to use when getting
-  ///   the random floating point.
-  /// - Returns: A random representation of this floating point.
+  /// Use this method to generate a floating-point value within a specific
+  /// range. This example creates three new values in the range
+  /// `${exampleRange}`.
   ///
-  /// This uses the standard library's default random number generator.
+  ///     for _ in 1...3 {
+  ///         print(Double.random(in: ${exampleRange}))
+  ///     }
+  ///     // Prints "18.1900709259179"
+  ///     // Prints "14.2286325689993"
+  ///     // Prints "13.1485686260762"
+  ///
+  /// The `random()` static method chooses a random value from a continuous
+  /// uniform distribution in `range`, and then converts that value to the
+  /// nearest representable value in this type. Depending on the size and span
+  /// of `range`, some concrete values may be represented more frequently than
+  /// others.
+  ///
+  /// This method uses the default random generator, `Random.default`. The call
+  /// to `Double.random(in: ${exampleRange})` above is equivalent to calling
+  /// `Double.random(in: ${exampleRange}, using: Random.default)`.
+  ///
+  /// - Parameter range: The range in which to create a random value.
+%   if Range == 'Range':
+  ///   `range` must not be empty.
+%   end
+  /// - Returns: A random value within the bounds of `range`.
   @inlinable
   public static func random(in range: ${Range}<Self>) -> Self {
     return Self.random(in: range, using: Random.default)

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -2484,29 +2484,30 @@ ${assignmentOperatorComment(x.operator, False)}
 }
 
 % for Range in ['Range', 'ClosedRange']:
+%   exampleRange = '1..<100' if Range == 'Range' else '1...100'
 
 extension ${Range}
 where Bound: FixedWidthInteger,
       Bound.Magnitude: UnsignedInteger {
       
-  /// Returns a random element from this collection.
+  /// Returns a random element of the range, using the given generator as
+  /// a source for randomness.
   ///
-  /// - Parameter generator: The random number generator to use when getting
+  /// You can use this method to select a random element of a range when you
+  /// are using a custom random number generator. If you're generating a random
+  /// number, in most cases, you should prefer using the `random(in:using:)`
+  /// static method of the desired numeric type. That static method is available
+  /// for both integer and floating point types, and returns a non-optional
+  /// value.
+  ///
+  /// - Parameter generator: The random number generator to use when choosing
   ///   a random element.
-  /// - Returns: A random element from this collection.
-  ///
-  /// A good example of this is getting a random greeting from an array:
-  ///
-  ///     let greetings = ["hi", "hey", "hello", "hola"]
-  ///     let randomGreeting = greetings.random()
-  ///
-  /// If the collection is empty, the value of this function is `nil`.
-  ///
-  ///     let numbers = [10, 20, 30, 40, 50]
-  ///     if let randomNumber = numbers.random() {
-  ///         print(randomNumber)
-  ///     }
-  ///     // Could print "20", perhaps
+  /// - Returns: A random element of the range.
+%   if 'Closed' not in Range:
+  ///   If the range is empty, the method returns `nil`.
+%   else:
+  ///   This method never returns `nil`.
+%   end
   @inlinable
   public func random<T: RandomNumberGenerator>(
     using generator: T
@@ -2552,26 +2553,26 @@ where Bound: FixedWidthInteger,
     }
   }
   
-  /// Returns a random element from this collection.
+  /// Returns a random element of the range, using the given generator as
+  /// a source for randomness.
   ///
-  /// - Parameter generator: The random number generator to use when getting
-  ///   a random element.
-  /// - Returns: A random element from this collection.
+  /// You can use this method to select a random element of a range when you
+  /// are using a custom random number generator. If you're generating a random
+  /// number, in most cases, you should prefer using the `random(in:)`
+  /// static method of the desired numeric type. That static method is available
+  /// for both integer and floating point types, and returns a non-optional
+  /// value.
   ///
-  /// A good example of this is getting a random greeting from an array:
+  /// This method uses the default random generator, `Random.default`. Calling
+  /// `(${exampleRange}).random()` is equivalent to calling
+  /// `(${exampleRange}).random(using: Random.default)`.
   ///
-  ///     let greetings = ["hi", "hey", "hello", "hola"]
-  ///     let randomGreeting = greetings.random()
-  ///
-  /// If the collection is empty, the value of this function is `nil`.
-  ///
-  ///     let numbers = [10, 20, 30, 40, 50]
-  ///     if let randomNumber = numbers.random() {
-  ///         print(randomNumber)
-  ///     }
-  ///     // Could print "20", perhaps
-  ///
-  /// This uses the standard library's default random number generator.
+  /// - Returns: A random element of the range.
+%   if 'Closed' not in Range:
+  ///   If the range is empty, the method returns `nil`.
+%   else:
+  ///   This method never returns `nil`.
+%   end
   @inlinable
   public func random() -> Element? {
     return self.random(using: Random.default)
@@ -2582,13 +2583,28 @@ extension FixedWidthInteger
 where Self.Stride : SignedInteger,
       Self.Magnitude : UnsignedInteger {
 
-  /// Returns a random representation of this integer within the range.
+  /// Returns a random value within the specified range, using the given
+  /// generator as a source for randomness.
   ///
-  /// - Parameter range: A ${Range} to determine the bounds to get a random value
-  ///   from.
-  /// - Parameter generator: The random number generator to use when getting
-  ///   the random integer.
-  /// - Returns: A random representation of this integer.
+  /// Use this method to generate an integer within a specific range when you
+  /// are using a custom random number generator. This example creates three
+  /// new values in the range `${exampleRange}`.
+  ///
+  ///     for _ in 1...3 {
+  ///         print(Int.random(in: ${exampleRange}, using: myGenerator))
+  ///     }
+  ///     // Prints "7"
+  ///     // Prints "44"
+  ///     // Prints "21"
+  ///
+  /// - Parameters:
+  ///   - range: The range in which to create a random value.
+%   if Range == 'Range':
+  ///     `range` must not be empty.
+%   end
+  ///   - generator: The random number generator to use when creating the
+  ///     new random value.
+  /// - Returns: A random value within the bounds of `range`.
   @inlinable
   public static func random<T: RandomNumberGenerator>(
     in range: ${Range}<Self>,
@@ -2603,15 +2619,27 @@ where Self.Stride : SignedInteger,
     return range.random(using: generator)!
   }
   
-  /// Returns a random representation of this integer within the range.
+  /// Returns a random value within the specified range.
   ///
-  /// - Parameter range: A ${Range} to determine the bounds to get a random value
-  ///   from.
-  /// - Parameter generator: The random number generator to use when getting
-  ///   the random integer.
-  /// - Returns: A random representation of this integer.
+  /// Use this method to generate an integer within a specific range. This
+  /// example creates three new values in the range `${exampleRange}`.
   ///
-  /// This uses the standard library's default random number generator.
+  ///     for _ in 1...3 {
+  ///         print(Int.random(in: ${exampleRange}))
+  ///     }
+  ///     // Prints "53"
+  ///     // Prints "64"
+  ///     // Prints "5"
+  ///
+  /// This method uses the default random generator, `Random.default`. The call
+  /// to `Int.random(in: ${exampleRange})` above is equivalent to calling
+  /// `Int.random(in: ${exampleRange}, using: Random.default)`.
+  ///
+  /// - Parameter range: The range in which to create a random value.
+%   if Range == 'Range':
+  ///   `range` must not be empty.
+%   end
+  /// - Returns: A random value within the bounds of `range`.
   @inlinable
   public static func random(in range: ${Range}<Self>) -> Self {
     return Self.random(in: range, using: Random.default)

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -2487,8 +2487,9 @@ ${assignmentOperatorComment(x.operator, False)}
 %   exampleRange = '1..<100' if Range == 'Range' else '1...100'
 
 extension ${Range}
-where Bound: FixedWidthInteger,
-      Bound.Magnitude: UnsignedInteger {
+  where Bound: FixedWidthInteger, Bound.Stride : SignedInteger,
+  Bound.Magnitude: UnsignedInteger
+{
       
   /// Returns a random element of the range, using the given generator as
   /// a source for randomness.

--- a/test/stdlib/Random.swift
+++ b/test/stdlib/Random.swift
@@ -105,6 +105,9 @@ func floatingPointRangeTest<T: BinaryFloatingPoint>(_ type: T.Type)
 RandomTests.test("random floating points in ranges") {
   floatingPointRangeTest(Float.self)
   floatingPointRangeTest(Double.self)
+}
+
+RandomTests.test("Float80: random floating points in ranges") {
   floatingPointRangeTest(Float80.self)
 }
 


### PR DESCRIPTION
This revises all the documentation for the new randomness APIs and adds a few benchmarks for generating random values and shuffling arrays.

There's a fix for the problem we were having with forwarding `Range<Int>.random()` to `Range<Int>.random(using:)` in https://github.com/Azoy/swift/commit/4fc39ce7ab0ed3db9b6ffc0f446a00b745220ff3. Also, https://github.com/Azoy/swift/commit/faaad69e4054953eb980a0df1e308898b73442af pulls out the `Float80` version of the floating-point test into its own failing test. (It looks like `maxSignificand + 1` is overflowing to zero when called on `Float80`, which then gets used as a divisor inside `next(upperBound:)`.)